### PR TITLE
docs: drop the wrong-package warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ dsh plugin --profile web add github:xiaoyuyu6420/dsh-backup
 
 Then restart `dsh web`.
 
-> ⚠️ **Don't install the wrong package**: the correct name is `@xiaoyuyu6420/dsh-backup`, with the scope. The unscoped `dsh-backup` on npm is an unrelated third-party package.
-
 ## Quickstart
 
 About 30 seconds:

--- a/README.zh.md
+++ b/README.zh.md
@@ -31,8 +31,6 @@ dsh plugin --profile web add github:xiaoyuyu6420/dsh-backup
 
 装完重启 `dsh web`。
 
-> ⚠️ **别装错包**：正确的包名是 `@xiaoyuyu6420/dsh-backup`，带前缀。npm 上另有一个不带前缀的 `dsh-backup`，那是无关的第三方项目，请勿安装。
-
 ## 快速上手
 
 大约 30 秒：


### PR DESCRIPTION
Removes the don't-install-wrong-package callout from both READMEs (ZH and EN). The troubleshooting entry for a wrong install stays.