### PR TITLE
fix(compat): install repo deps + e2e via tarball with panel RPC assertion

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -34,6 +34,14 @@ jobs:
       - name: Install latest dsh host
         run: npm i -g @deepseek-ai/dsh@latest
 
+      # e2e 以 link 方式挂载本仓库，插件的 peer imports 从 repo 的 node_modules 解析——
+      # 必须先装依赖（含 auto-install 的 peers），否则 boot 报 Cannot find package（见 run 32775395308）。
+      - name: Install repo dependencies (peers resolve from here)
+        env:
+          npm_config_minimum_release_age: 0
+          npm_config_minimumReleaseAge: 0
+        run: pnpm install
+
       # 本 job 的职责就是追新：显式豁免 pnpm 默认 24h 冷却期，
       # 否则新列车发布后 24h 内本巡检必然红（与日常 CI 的默认防线不冲突）。
       - name: Run isolated-host e2e against latest train

--- a/scripts/e2e-host.mjs
+++ b/scripts/e2e-host.mjs
@@ -14,6 +14,7 @@
  */
 
 import { spawn, spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -41,6 +42,7 @@ function run(cmd, args, opts = {}) {
 
 let bootProc = null;
 let home = null;
+let packDir = null;
 let bootLogPath = null;
 let bootLogStream = null;
 
@@ -106,10 +108,18 @@ async function waitBoot() {
 async function main() {
   console.log(`[e2e-host] repo=${repoRoot} port=${PORT}`);
 
-  // ---------- 准备：隔离 DSH_HOME + link 本地包 ----------
+  // ---------- 准备：隔离 DSH_HOME + tarball 安装 ----------
+  // 不用 `dsh plugin add <repo>`（link 方式）：link 引导的 profile 里 panel RPC 报
+  // `active Service "backupPanel" is unavailable`（宿主 link 路径的差异，npm/tarball 正常）。
+  // tarball 安装 = 真实用户路径，且顺带验证发布物内容。
   if (!spawnSync('dsh', ['--version']).status === 0) throw new Error('PATH 里找不到 dsh CLI');
   home = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-e2e-'));
-  run('dsh', ['plugin', '--profile', 'web', 'add', repoRoot], { env: { ...process.env, DSH_HOME: home }, cwd: path.dirname(home) });
+  packDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-e2e-pack-'));
+  console.log(`[e2e-host] 打包 tarball...`);
+  run('pnpm', ['pack', '--pack-destination', packDir], { cwd: repoRoot });
+  const tarball = fs.readdirSync(packDir).find((f) => f.endsWith('.tgz'));
+  if (!tarball) throw new Error('pnpm pack 未产出 tarball');
+  run('dsh', ['plugin', '--profile', 'web', 'add', path.join(packDir, tarball)], { env: { ...process.env, DSH_HOME: home }, cwd: path.dirname(home) });
 
   const patchFile = path.join(home, 'profiles', 'web', 'cordis.patch.yml');
   fs.writeFileSync(patchFile, [
@@ -131,6 +141,33 @@ async function main() {
     indexHtml.includes('/plugins/@deepseek-ai/dsh-client-modules/client.js'),
     'HTML 缺少 dsh-client-modules/client.js 预加载——宿主可能是旧列车或插件树未进 web 组合',
   );
+
+  // panel RPC 可用性（link 安装的 profile 会报 service-unavailable，tarball/npm 正常）
+  let rpcDetail = '请求失败';
+  let rpcOk = false;
+  try {
+    const rpcRes = await fetch(`${BASE}/api/backupPanel/status`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'client-request',
+        rpcId: randomUUID(),
+        method: 'backupPanel/status',
+        payload: { args: {} },
+      }),
+    });
+    const rpcText = await rpcRes.text();
+    try {
+      const rpc = JSON.parse(rpcText);
+      rpcOk = rpc?.type === 'server-response' && rpc?.result?.ok === true;
+      rpcDetail = `HTTP ${rpcRes.status} ${rpcText.slice(0, 200)}`;
+    } catch {
+      rpcDetail = `HTTP ${rpcRes.status} 非JSON: ${rpcText.slice(0, 120)}`;
+    }
+  } catch (err) {
+    rpcDetail = `fetch 异常: ${err.message}`;
+  }
+  check('panel RPC backupPanel/status 可调用', rpcOk, rpcDetail);
 
   // ---------- settings seam ----------
   const settingsRes = await fetch(`${BASE}/dsh-backup/settings`).then((r) => r.json()).catch(() => null);
@@ -204,4 +241,5 @@ try {
 } finally {
   await stopBoot();
   if (home) fs.rmSync(home, { recursive: true, force: true });
+  if (packDir) fs.rmSync(packDir, { recursive: true, force: true });
 }


### PR DESCRIPTION
Two compat/e2e hardening fixes from live-fire testing:

1. **Root cause of both failed compat runs**: the e2e links the repo into the isolated profile, and the plugin's peer imports resolve from the repo's own node_modules — which never exists on the runner because the job skipped pnpm install. Adds the missing install step (minimumReleaseAge=0 kept for this job only).

2. **e2e upgrade — tarball install + panel RPC assertion**: link-installed profiles hit `active Service "backupPanel" is unavailable` on the typert gateway (host link-path quirk; reproduces with 0.7.2 and 0.8.0 alike, npm/tarball installs are clean). The e2e now `pnpm pack`s and installs the tarball — mirroring the real user path, exercising the shipped artifact — and asserts `POST /api/backupPanel/status`, giving the panel RPC link its first CI coverage.

Local verification: 11/11 (boot, HTML preload, panel RPC, settings seam incl. 409/400/persist-across-restart/reset).