### PR TITLE
chore: release 0.9.1 — panel feedback link + README makeover on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xiaoyuyu6420/dsh-backup",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Backup, restore, download and GitHub-sync DeepSeek Harness user data (~/.dsh): /backup, scheduled auto-backup that survives restarts, sha256 checksums, integrity verify, rotation, credential redaction with a local vault (plaintext never leaves the machine), cross-machine restore preflight with github pull, and a visual Settings panel. Cross-platform (macOS/Linux/Windows). 一键备份与恢复 DSH 数据：定时自动备份、完整性校验、凭据默认脱敏（明文只存本机 vault）、跨机恢复预检与 github pull 拉取，附 Settings 可视面板。",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
发版内容（自 v0.9.0 以来的 main 变更）：

- **面板反馈入口**（PR #36）：备份列表下方「说两句，直达反馈帖 →」，双语，直达 Discussions #32 —— 触达存量周活用户（npm 周下载 1542）的反馈转化点
- **README 全面改版**（PR #33）：痛点前置、真实演示输出、双面板截图、FAQ —— 同时刷新 npmjs.com 上的陈旧 README（只有发新版本才会更新）
- 反馈战役基础设施（PR #34/#35）

**合并后打 tag `v0.9.1` 即触发 publish 工作流**（走 CI tag + NPM_TOKEN 免交互，不需要 OTP）。打不打、何时打由你拍板——我不替你发版。