### PR TITLE
fix(ci): publish.yml 补回 registry-url（发布 ENEEDAUTH 根因）

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          registry-url: https://registry.npmjs.org
 
       - name: Install pnpm
         run: npm i -g pnpm@11.24.0


### PR DESCRIPTION
#56 重构 publish.yml 时删掉了 setup-node 的 registry-url，NODE_AUTH_TOKEN 不再生效，v0.10.0 首次发布报 ENEEDAUTH（0.9.1 成功那次的日志对比实锤：当时带 registry-url）。补回一行即恢复 CI 发版链路。