### PR TITLE
fix(doctor): 补首帧容器契约校验——单帧重写型损坏不再漏检（#66）

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1851,7 +1851,9 @@ export function apply(ctx, pluginConfig) {
 
   /**
    * 按 RFC 8878 结构走查拼接帧的字节边界（不解压）：返回 [start,end] 区间数组；
-   * 结构不合法（截断/未知魔数/保留位/越界块）抛错。skippable 帧一并支持。
+   * 结构不合法（截断/未知魔数/保留位/越界块）抛错。
+   * skippable 帧直接判非法——宿主 scanZstdFrames 拒绝一切非数据帧魔数，
+   * 这类文件宿主整体拒载，容忍它们会造成「doctor 报 OK、宿主编译系统读不了」。
    */
   function walkZstdFrames(buf) {
     const frames = [];
@@ -1890,12 +1892,7 @@ export function apply(ctx, pluginConfig) {
         frames.push([off, pos]);
         off = pos;
       } else if (magic >= 0x184d2a50 && magic <= 0x184d2a5f) {
-        if (buf.length - off < 8) throw new Error('skippable 帧头截断');
-        const size = buf.readUInt32LE(off + 4);
-        const end = off + 8 + size;
-        if (end > buf.length) throw new Error('skippable 帧数据越界');
-        frames.push([off, end]);
-        off = end;
+        throw new Error('遇 skippable 帧——宿主读端不支持任何非数据帧魔数，整个文件将被拒载');
       } else {
         throw new Error(`偏移 ${off} 处不是 zstd 帧魔数`);
       }
@@ -1905,20 +1902,21 @@ export function apply(ctx, pluginConfig) {
 
   /**
    * 解出 .zstd 会话日志的全部逻辑行；任一帧损坏即抛错（错误含偏移信息）。
-   * 同时返回首个数据帧（zstd 魔数，非 skippable）解出的行数 headerFrameLines——
-   * 宿主容器契约要求首帧恰好一行 SessionHeader，行流拼接校验覆盖不到（#66）。
+   * 同时对首个数据帧做宿主容器契约判定 headerFrameOk——宿主 assertZstdHeaderFrame
+   * 是字节精确的：首帧解出必须非空、且首个换行符恰在最后一个字节（即「恰好
+   * 一行、以单个 \n 结尾」）。行流拼接校验覆盖不到这条（#66）。
    */
   function decodeZstdLog(buf) {
     const parts = [];
     let frameNo = 0;
-    let headerFrameLines;
+    let headerFrameOk;
     for (const [s, e] of walkZstdFrames(buf)) {
       frameNo += 1;
       try {
         const out = zlib.zstdDecompressSync(buf.subarray(s, e));
         parts.push(out);
-        if (headerFrameLines === undefined && buf.readUInt32LE(s) === ZSTD_MAGIC) {
-          headerFrameLines = out.toString('utf8').split('\n').filter((l) => l.length > 0).length;
+        if (headerFrameOk === undefined) {
+          headerFrameOk = out.length > 0 && out.indexOf(10) === out.length - 1;
         }
       } catch (err) {
         throw new Error(`第 ${frameNo} 帧解压失败（${e - s}B）：${String(err && err.message ? err.message : err)}`);
@@ -1926,7 +1924,7 @@ export function apply(ctx, pluginConfig) {
     }
     return {
       lines: Buffer.concat(parts).toString('utf8').split('\n').filter((l) => l.length > 0),
-      headerFrameLines,
+      headerFrameOk,
     };
   }
 
@@ -2008,13 +2006,14 @@ export function apply(ctx, pluginConfig) {
         return { state: 'skipped', reason: `文件 ${Math.floor(info.size / 1048576)}MB 超过深度校验上限（${Math.floor(HASH_MAX_BYTES / 1048576)}MB），不整读入内存` };
       }
       let lines;
-      let headerFrameLines;
+      let headerFrameOk;
       if (f.abs.endsWith('.zstd')) {
-        ({ lines, headerFrameLines } = decodeZstdLog(await readFile(f.abs)));
-        // 容器契约（#66/#1047）：首帧必须恰好一行 header。外部工具单帧重写的
-        // 文件内容完整可解、行级校验全过，宿主读端却整体拒载——行流判不出。
-        if (headerFrameLines !== undefined && headerFrameLines !== 1) {
-          return { state: 'bad', reason: `首帧解出 ${headerFrameLines} 行——违反容器契约（首帧应恰好一行 SessionHeader；整份日志被外部工具压成单帧的典型形态，宿主读端会拒载）` };
+        ({ lines, headerFrameOk } = decodeZstdLog(await readFile(f.abs)));
+        // 容器契约（#66/#1047）：首帧必须解出「恰好一行 header、以单个换行
+        // 结尾」（字节精确，对齐宿主 assertZstdHeaderFrame）。单帧重写、帧内
+        // 多余空行、缺行尾的文件内容完整可解、行级校验全过，宿主却整体拒载。
+        if (headerFrameOk === false) {
+          return { state: 'bad', reason: '首帧不是恰好一行 header——违反容器契约（首帧应解出一行 SessionHeader 且以单个换行结尾；单帧重写/多余空行/缺行尾的典型形态，宿主读端会拒载）' };
         }
       } else {
         lines = (await readFile(f.abs, 'utf8')).split('\n').filter((l) => l.length > 0);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1828,9 +1828,12 @@ export function apply(ctx, pluginConfig) {
   // 布局与格式依据宿主内置的 @deepseek-ai/dsh-session-persistence-jsonl：
   //   <会话根>/--<项目目录>--/<编码后 id>/session.jsonl.zstd（compression:'none' 时为 .jsonl）
   // zstd 文件是独立帧的拼接：首帧是带校验和的 SessionHeader 行，其后每个追加批一帧。
+  // 两条硬契约都对齐宿主读端：①行级——首行 SessionHeader、seq 连续；②容器级——
+  // 首帧解出来恰好一行 header（宿主 assertZstdHeaderFrame；外部工具把整份日志
+  // 压成单帧时内容完整可解、宿主却拒载，行级校验覆盖不到，必须单独判）。
   // Node 内置 zstd 解码器不跨帧续读，因此先按 RFC 8878 走帧字节边界
   // （魔数/帧头/块序列/校验和），再逐帧解出逻辑行。检测目标正是社区高频的
-  // "corrupt session log"灾难：并发写 seq 撞号、坏帧、尾部截断。
+  // "corrupt session log"灾难：并发写 seq 撞号、坏帧、尾部截断、单帧重写。
   const ZSTD_MAGIC = 0xfd2fb528;
   const SESSION_LOG_NAMES = new Set(['session.jsonl.zstd', 'session.jsonl']);
   const SCAN_SKIP_DIRS = new Set(['node_modules', '.system', '.git', 'vault']);
@@ -1900,19 +1903,31 @@ export function apply(ctx, pluginConfig) {
     return frames;
   }
 
-  /** 解出 .zstd 会话日志的全部逻辑行；任一帧损坏即抛错（错误含偏移信息）。 */
+  /**
+   * 解出 .zstd 会话日志的全部逻辑行；任一帧损坏即抛错（错误含偏移信息）。
+   * 同时返回首个数据帧（zstd 魔数，非 skippable）解出的行数 headerFrameLines——
+   * 宿主容器契约要求首帧恰好一行 SessionHeader，行流拼接校验覆盖不到（#66）。
+   */
   function decodeZstdLog(buf) {
     const parts = [];
     let frameNo = 0;
+    let headerFrameLines;
     for (const [s, e] of walkZstdFrames(buf)) {
       frameNo += 1;
       try {
-        parts.push(zlib.zstdDecompressSync(buf.subarray(s, e)));
+        const out = zlib.zstdDecompressSync(buf.subarray(s, e));
+        parts.push(out);
+        if (headerFrameLines === undefined && buf.readUInt32LE(s) === ZSTD_MAGIC) {
+          headerFrameLines = out.toString('utf8').split('\n').filter((l) => l.length > 0).length;
+        }
       } catch (err) {
         throw new Error(`第 ${frameNo} 帧解压失败（${e - s}B）：${String(err && err.message ? err.message : err)}`);
       }
     }
-    return Buffer.concat(parts).toString('utf8').split('\n').filter((l) => l.length > 0);
+    return {
+      lines: Buffer.concat(parts).toString('utf8').split('\n').filter((l) => l.length > 0),
+      headerFrameLines,
+    };
   }
 
   /**
@@ -1993,8 +2008,14 @@ export function apply(ctx, pluginConfig) {
         return { state: 'skipped', reason: `文件 ${Math.floor(info.size / 1048576)}MB 超过深度校验上限（${Math.floor(HASH_MAX_BYTES / 1048576)}MB），不整读入内存` };
       }
       let lines;
+      let headerFrameLines;
       if (f.abs.endsWith('.zstd')) {
-        lines = decodeZstdLog(await readFile(f.abs));
+        ({ lines, headerFrameLines } = decodeZstdLog(await readFile(f.abs)));
+        // 容器契约（#66/#1047）：首帧必须恰好一行 header。外部工具单帧重写的
+        // 文件内容完整可解、行级校验全过，宿主读端却整体拒载——行流判不出。
+        if (headerFrameLines !== undefined && headerFrameLines !== 1) {
+          return { state: 'bad', reason: `首帧解出 ${headerFrameLines} 行——违反容器契约（首帧应恰好一行 SessionHeader；整份日志被外部工具压成单帧的典型形态，宿主读端会拒载）` };
+        }
       } else {
         lines = (await readFile(f.abs, 'utf8')).split('\n').filter((l) => l.length > 0);
       }

--- a/rescue/rescue.mjs
+++ b/rescue/rescue.mjs
@@ -238,12 +238,9 @@ function walkZstdFrames(buf) {
       frames.push([off, pos]);
       off = pos;
     } else if (magic >= 0x184d2a50 && magic <= 0x184d2a5f) {
-      if (buf.length - off < 8) throw new Error('skippable 帧头截断');
-      const size = buf.readUInt32LE(off + 4);
-      const end = off + 8 + size;
-      if (end > buf.length) throw new Error('skippable 帧数据越界');
-      frames.push([off, end]);
-      off = end;
+      // 宿主 scanZstdFrames 拒绝一切非数据帧魔数——容忍 skippable 会造成
+      // 「doctor 报 OK、宿主整体拒载」（#66，与 lib/index.js 同步）
+      throw new Error('遇 skippable 帧——宿主读端不支持任何非数据帧魔数，整个文件将被拒载');
     } else {
       throw new Error(`偏移 ${off} 处不是 zstd 帧魔数`);
     }
@@ -252,21 +249,22 @@ function walkZstdFrames(buf) {
 }
 
 /**
- * 解出 .zstd 会话日志的全部逻辑行；任一帧损坏即抛错。同时返回首个数据帧
- * （zstd 魔数，非 skippable）解出的行数 headerFrameLines——宿主容器契约要求
- * 首帧恰好一行 SessionHeader，行流拼接校验覆盖不到（#66，与 lib/index.js 同步）。
+ * 解出 .zstd 会话日志的全部逻辑行；任一帧损坏即抛错。同时对首个数据帧做
+ * 宿主容器契约判定 headerFrameOk——宿主 assertZstdHeaderFrame 是字节精确的：
+ * 首帧解出必须非空、且首个换行符恰在最后一个字节（「恰好一行、单个 \n 结尾」）。
+ * 行流拼接校验覆盖不到这条（#66，与 lib/index.js 同步）。
  */
 function decodeZstdLog(buf) {
   const parts = [];
   let frameNo = 0;
-  let headerFrameLines;
+  let headerFrameOk;
   for (const [s, e] of walkZstdFrames(buf)) {
     frameNo += 1;
     try {
       const out = zlib.zstdDecompressSync(buf.subarray(s, e));
       parts.push(out);
-      if (headerFrameLines === undefined && buf.readUInt32LE(s) === ZSTD_MAGIC) {
-        headerFrameLines = out.toString('utf8').split('\n').filter((l) => l.length > 0).length;
+      if (headerFrameOk === undefined) {
+        headerFrameOk = out.length > 0 && out.indexOf(10) === out.length - 1;
       }
     } catch (err) {
       throw new Error(`第 ${frameNo} 帧解压失败：${String(err && err.message ? err.message : err)}`);
@@ -274,7 +272,7 @@ function decodeZstdLog(buf) {
   }
   return {
     lines: Buffer.concat(parts).toString('utf8').split('\n').filter((l) => l.length > 0),
-    headerFrameLines,
+    headerFrameOk,
   };
 }
 
@@ -342,12 +340,12 @@ async function validateSessionFile(f) {
       return { state: 'skipped', reason: `文件 ${Math.floor(info.size / 1048576)}MB 超过深度校验上限` };
     }
     let lines;
-    let headerFrameLines;
+    let headerFrameOk;
     if (f.abs.endsWith('.zstd')) {
-      ({ lines, headerFrameLines } = decodeZstdLog(await fs.readFile(f.abs)));
-      // 容器契约（#66/#1047）：首帧必须恰好一行 header，单帧重写形态宿主拒载
-      if (headerFrameLines !== undefined && headerFrameLines !== 1) {
-        return { state: 'bad', reason: `首帧解出 ${headerFrameLines} 行——违反容器契约（首帧应恰好一行 SessionHeader；整份日志被外部工具压成单帧的典型形态，宿主读端会拒载）` };
+      ({ lines, headerFrameOk } = decodeZstdLog(await fs.readFile(f.abs)));
+      // 容器契约（#66/#1047）：首帧必须解出「恰好一行 header、单个换行结尾」
+      if (headerFrameOk === false) {
+        return { state: 'bad', reason: '首帧不是恰好一行 header——违反容器契约（首帧应解出一行 SessionHeader 且以单个换行结尾；单帧重写/多余空行/缺行尾的典型形态，宿主读端会拒载）' };
       }
     } else {
       lines = (await fs.readFile(f.abs, 'utf8')).split('\n').filter((l) => l.length > 0);

--- a/rescue/rescue.mjs
+++ b/rescue/rescue.mjs
@@ -251,18 +251,31 @@ function walkZstdFrames(buf) {
   return frames;
 }
 
+/**
+ * 解出 .zstd 会话日志的全部逻辑行；任一帧损坏即抛错。同时返回首个数据帧
+ * （zstd 魔数，非 skippable）解出的行数 headerFrameLines——宿主容器契约要求
+ * 首帧恰好一行 SessionHeader，行流拼接校验覆盖不到（#66，与 lib/index.js 同步）。
+ */
 function decodeZstdLog(buf) {
   const parts = [];
   let frameNo = 0;
+  let headerFrameLines;
   for (const [s, e] of walkZstdFrames(buf)) {
     frameNo += 1;
     try {
-      parts.push(zlib.zstdDecompressSync(buf.subarray(s, e)));
+      const out = zlib.zstdDecompressSync(buf.subarray(s, e));
+      parts.push(out);
+      if (headerFrameLines === undefined && buf.readUInt32LE(s) === ZSTD_MAGIC) {
+        headerFrameLines = out.toString('utf8').split('\n').filter((l) => l.length > 0).length;
+      }
     } catch (err) {
       throw new Error(`第 ${frameNo} 帧解压失败：${String(err && err.message ? err.message : err)}`);
     }
   }
-  return Buffer.concat(parts).toString('utf8').split('\n').filter((l) => l.length > 0);
+  return {
+    lines: Buffer.concat(parts).toString('utf8').split('\n').filter((l) => l.length > 0),
+    headerFrameLines,
+  };
 }
 
 function validateSessionLines(lines) {
@@ -329,8 +342,13 @@ async function validateSessionFile(f) {
       return { state: 'skipped', reason: `文件 ${Math.floor(info.size / 1048576)}MB 超过深度校验上限` };
     }
     let lines;
+    let headerFrameLines;
     if (f.abs.endsWith('.zstd')) {
-      lines = decodeZstdLog(await fs.readFile(f.abs));
+      ({ lines, headerFrameLines } = decodeZstdLog(await fs.readFile(f.abs)));
+      // 容器契约（#66/#1047）：首帧必须恰好一行 header，单帧重写形态宿主拒载
+      if (headerFrameLines !== undefined && headerFrameLines !== 1) {
+        return { state: 'bad', reason: `首帧解出 ${headerFrameLines} 行——违反容器契约（首帧应恰好一行 SessionHeader；整份日志被外部工具压成单帧的典型形态，宿主读端会拒载）` };
+      }
     } else {
       lines = (await fs.readFile(f.abs, 'utf8')).split('\n').filter((l) => l.length > 0);
     }

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -809,16 +809,21 @@ async function main() {
         const mock20 = makeCtx({ home: env20.home, dsh: env20.dsh });
         plugin(mock20.ctx, {});
         const sessDir = path.join(env20.dsh, 'sessions', '--proj--');
-        // 五个会话目录先全部写入健康内容，再备份（归档持健康副本），最后弄坏三个现场
+        // 五个会话目录先全部写入健康内容，再备份（归档持健康副本），最后弄坏四个现场
         const good = makeZstdSessionLog('sess-good');
         const rawLines = makeSessionLogLines('sess-raw');
         // raw 样本只取 header + 两条裸事件（packed 行属 zstd 帧布局，raw 版不带）
         const rawGood = Buffer.from(rawLines.slice(0, 3).join('\n'), 'utf8');
+        // #1047 形态备用：整份合法日志压成单帧（无 zstd 运行时的占位内容无所谓）
+        const singleFrame = typeof zlib.zstdCompressSync === 'function'
+          ? zlib.zstdCompressSync(`${makeSessionLogLines('sess-single').join('\n')}\n`)
+          : Buffer.from('placeholder-zstd-log-sess-single');
         const files = [
           ['enc-good', 'session.jsonl.zstd', good],
           ['raw-good', 'session.jsonl', rawGood],
           ['enc-magic', 'session.jsonl.zstd', good],
           ['enc-trunc', 'session.jsonl.zstd', makeZstdSessionLog('sess-trunc')],
+          ['enc-single', 'session.jsonl.zstd', good],
           ['raw-gap', 'session.jsonl', rawGood],
         ];
         for (const [dirName, fileName, content] of files) {
@@ -827,28 +832,30 @@ async function main() {
         }
         ok((await mock20.tool().execute({ mode: 'backup' }, {})).ok === true, 'doctor 场景备份成功');
 
-        // 弄坏三个现场：坏魔数 / 截断帧 / seq 跳号
+        // 弄坏四个现场：坏魔数 / 截断帧 / 单帧重写（#1047 形态）/ seq 跳号
         await fs.writeFile(path.join(sessDir, 'enc-magic', 'session.jsonl.zstd'), Buffer.from('definitely not zstd output!!'));
         await fs.writeFile(path.join(sessDir, 'enc-trunc', 'session.jsonl.zstd'), good.subarray(0, good.length - 4));
+        await fs.writeFile(path.join(sessDir, 'enc-single', 'session.jsonl.zstd'), singleFrame);
         await fs.writeFile(
           path.join(sessDir, 'raw-gap', 'session.jsonl'),
           [makeSessionLogLines('x')[0], JSON.stringify({ type: 'user/message', seq: 0 }), JSON.stringify({ type: 'user/message', seq: 2 })].join('\n'),
         );
 
         const scan = await mock20.tool().execute({ mode: 'doctor' }, {});
-        // 运行时自适应：Node ≥22.15/23.8 才有内置 zstd 解码。有 → 3 个损坏全检出；
+        // 运行时自适应：Node ≥22.15/23.8 才有内置 zstd 解码。有 → 4 个损坏全检出；
         // 无（如 Node 20）→ zstd 文件进 skipped、只有 raw 跳号可检出——这正是
         // HAS_NODE_ZSTD 降级路径的实测。
         const { zstdDecompressSync: probe } = await import('node:zlib');
         const zstdOk = typeof probe === 'function';
-        const expectBad = zstdOk ? 3 : 1;
+        const expectBad = zstdOk ? 4 : 1;
         const dump = scan.corrupt.map((c) => `${c.path} ← ${c.reason}`).join(' | ');
         ok(scan.ok === false && scan.corruptCount === expectBad, `扫描检出 ${expectBad} 个损坏（实际 ${scan.corruptCount}）`);
         if (zstdOk) {
           ok(scan.corrupt.some((c) => c.path.includes('enc-magic')), `坏魔数检出: ${dump}`);
           ok(scan.corrupt.some((c) => c.path.includes('enc-trunc')), '截断帧检出');
+          ok(scan.corrupt.some((c) => c.path.includes('enc-single') && c.reason.includes('容器契约')), `单帧重写违反容器契约检出（#1047 形态）: ${dump}`);
         } else {
-          ok(scan.skippedCount === 3, `无 zstd 运行时：3 个 .zstd 全部标记 skipped 而非损坏（实际 ${scan.skippedCount}）`);
+          ok(scan.skippedCount === 4, `无 zstd 运行时：4 个 .zstd 全部标记 skipped 而非损坏（实际 ${scan.skippedCount}）`);
           ok(scan.corrupt.every((c) => !c.path.endsWith('.zstd')), `损坏清单只含 raw 文件: ${dump}`);
           ok(scan.summary.includes('未能深度校验'), '扫描汇总提示 skipped');
         }
@@ -858,11 +865,12 @@ async function main() {
         const cmdScan = await mock20.handler('doctor');
         ok(cmdScan.kind === 'error' && cmdScan.text.includes('/backup doctor --repair'), '命令面 doctor 报告损坏并提示修复用法');
 
-        const repairTargets = zstdOk ? ['enc-magic', 'enc-trunc', 'raw-gap'] : ['raw-gap'];
+        const repairTargets = zstdOk ? ['enc-magic', 'enc-trunc', 'enc-single', 'raw-gap'] : ['raw-gap'];
         const repair = await mock20.tool().execute({ mode: 'doctor', selector: 'latest', repair: true }, {});
         ok(repair.ok === true && repair.repaired.length === expectBad, `定点修复 ${expectBad} 个（实际 ${repair.repaired.length}）`);
         if (zstdOk) {
           ok(await fs.readFile(path.join(sessDir, 'enc-magic', 'session.jsonl.zstd')).then((b) => b.equals(good)), '坏魔数文件已还原为健康字节');
+          ok(await fs.readFile(path.join(sessDir, 'enc-single', 'session.jsonl.zstd')).then((b) => b.equals(good)), '单帧重写文件已还原为多帧健康字节');
         }
         ok(await fs.readFile(path.join(sessDir, 'raw-gap', 'session.jsonl'), 'utf8').then((t) => t === rawGood.toString('utf8')), 'seq 跳号文件已还原');
         let keptCount = 0;
@@ -935,6 +943,13 @@ async function main() {
         const rawGood = Buffer.from(rawLines.slice(0, 3).join('\n'), 'utf8');
         await fs.mkdir(path.join(sessDir, 'enc-a'), { recursive: true });
         await fs.writeFile(path.join(sessDir, 'enc-a', 'session.jsonl.zstd'), good);
+        // enc-single：先写健康多帧（进归档，供 doctor --repair 定点还原），弄坏动作在 doctor 段
+        const { zstdDecompressSync: probe23 } = await import('node:zlib');
+        const zstd23 = typeof probe23 === 'function';
+        if (zstd23) {
+          await fs.mkdir(path.join(sessDir, 'enc-single'), { recursive: true });
+          await fs.writeFile(path.join(sessDir, 'enc-single', 'session.jsonl.zstd'), good);
+        }
         await fs.mkdir(path.join(sessDir, 'raw-b'), { recursive: true });
         await fs.writeFile(path.join(sessDir, 'raw-b', 'session.jsonl'), rawGood);
         await mock23.handler('');
@@ -972,13 +987,22 @@ async function main() {
           srv.kill();
         }
 
-        // doctor：弄坏 raw 文件 → rescue 检出并定点修复
+        // doctor：弄坏 raw 文件 + 单帧重写（#1047 形态，rescue.mjs 的容器契约校验）→ rescue 检出并定点修复
         await fs.writeFile(path.join(sessDir, 'raw-b', 'session.jsonl'), [rawLines[0], JSON.stringify({ type: 'user/message', seq: 0 }), JSON.stringify({ type: 'user/message', seq: 5 })].join('\n'));
+        if (zstd23) {
+          await fs.writeFile(path.join(sessDir, 'enc-single', 'session.jsonl.zstd'), zlib.zstdCompressSync(`${makeSessionLogLines('sess-r2').join('\n')}\n`));
+        }
         const doc = r(['doctor']);
         ok(doc.status === 1 && doc.stdout.includes('raw-b'), `rescue doctor 检出损坏: ${(doc.stdout.match(/❌[^\n]*/) || ['(无)']).join(' ')}`);
+        if (zstd23) {
+          ok(doc.stdout.includes('enc-single') && doc.stdout.includes('容器契约'), `rescue doctor 检出单帧重写（#66）: ${(doc.stdout.match(/❌[^\n]*/) || ['(无)']).join(' ')}`);
+        }
         const rep = r(['doctor', '--repair']);
         ok(rep.status === 0 && rep.stdout.includes('复检全部健康'), `rescue doctor --repair: ${(rep.stdout || rep.stderr).split('\n')[0]}`);
         ok(await fs.readFile(path.join(sessDir, 'raw-b', 'session.jsonl'), 'utf8').then((t) => t === rawGood.toString('utf8')), 'rescue 修复后字节一致');
+        if (zstd23) {
+          ok(await fs.readFile(path.join(sessDir, 'enc-single', 'session.jsonl.zstd')).then((b) => b.equals(good)), 'rescue 单帧重写已还原为多帧健康字节');
+        }
 
         // 空目标机恢复：整个 .dsh 删掉，rescue 独立拉回（vault 凭据还原）
         await fs.rm(env23.dsh, { recursive: true, force: true });

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -818,12 +818,27 @@ async function main() {
         const singleFrame = typeof zlib.zstdCompressSync === 'function'
           ? zlib.zstdCompressSync(`${makeSessionLogLines('sess-single').join('\n')}\n`)
           : Buffer.from('placeholder-zstd-log-sess-single');
+        // review 抓出的边界负样本（宿主 assertZstdHeaderFrame 字节精确拒载、
+        // 内容完整可解的四族形态；无 zstd 运行时用占位，走 skipped 路径）
+        const zstdC = typeof zlib.zstdCompressSync === 'function' ? (t) => zlib.zstdCompressSync(t) : () => Buffer.from('placeholder');
+        const hdrTxt = `${makeSessionLogLines('sess-hdr')[0]}\n`;
+        const evTxt = `${makeSessionLogLines('sess-hdr')[1]}\n`;
+        const skipFrame = () => {
+          const b = Buffer.alloc(16);
+          b.writeUInt32LE(0x184d2a50, 0);
+          b.writeUInt32LE(8, 4); // magic + size + 8B junk
+          return b;
+        };
         const files = [
           ['enc-good', 'session.jsonl.zstd', good],
           ['raw-good', 'session.jsonl', rawGood],
           ['enc-magic', 'session.jsonl.zstd', good],
           ['enc-trunc', 'session.jsonl.zstd', makeZstdSessionLog('sess-trunc')],
           ['enc-single', 'session.jsonl.zstd', good],
+          ['enc-trail', 'session.jsonl.zstd', good],
+          ['enc-lead', 'session.jsonl.zstd', good],
+          ['enc-notail', 'session.jsonl.zstd', good],
+          ['enc-skip', 'session.jsonl.zstd', good],
           ['raw-gap', 'session.jsonl', rawGood],
         ];
         for (const [dirName, fileName, content] of files) {
@@ -832,30 +847,39 @@ async function main() {
         }
         ok((await mock20.tool().execute({ mode: 'backup' }, {})).ok === true, 'doctor 场景备份成功');
 
-        // 弄坏四个现场：坏魔数 / 截断帧 / 单帧重写（#1047 形态）/ seq 跳号
+        // 弄坏八个现场：坏魔数 / 截断帧 / 单帧重写（#1047 形态）/ 首帧尾随空行 /
+        // 首帧前导空行 / 首帧缺行尾 / skippable 前导帧（宿主一律拒载）/ seq 跳号
         await fs.writeFile(path.join(sessDir, 'enc-magic', 'session.jsonl.zstd'), Buffer.from('definitely not zstd output!!'));
         await fs.writeFile(path.join(sessDir, 'enc-trunc', 'session.jsonl.zstd'), good.subarray(0, good.length - 4));
         await fs.writeFile(path.join(sessDir, 'enc-single', 'session.jsonl.zstd'), singleFrame);
+        await fs.writeFile(path.join(sessDir, 'enc-trail', 'session.jsonl.zstd'), Buffer.concat([zstdC(`${hdrTxt}\n`), zstdC(evTxt)]));
+        await fs.writeFile(path.join(sessDir, 'enc-lead', 'session.jsonl.zstd'), Buffer.concat([zstdC(`\n${hdrTxt}`), zstdC(evTxt)]));
+        await fs.writeFile(path.join(sessDir, 'enc-notail', 'session.jsonl.zstd'), Buffer.concat([zstdC(hdrTxt.replace(/\n$/, '')), zstdC(evTxt)]));
+        await fs.writeFile(path.join(sessDir, 'enc-skip', 'session.jsonl.zstd'), Buffer.concat([skipFrame(), zstdC(hdrTxt), zstdC(evTxt)]));
         await fs.writeFile(
           path.join(sessDir, 'raw-gap', 'session.jsonl'),
           [makeSessionLogLines('x')[0], JSON.stringify({ type: 'user/message', seq: 0 }), JSON.stringify({ type: 'user/message', seq: 2 })].join('\n'),
         );
 
         const scan = await mock20.tool().execute({ mode: 'doctor' }, {});
-        // 运行时自适应：Node ≥22.15/23.8 才有内置 zstd 解码。有 → 4 个损坏全检出；
+        // 运行时自适应：Node ≥22.15/23.8 才有内置 zstd 解码。有 → 8 个损坏全检出；
         // 无（如 Node 20）→ zstd 文件进 skipped、只有 raw 跳号可检出——这正是
         // HAS_NODE_ZSTD 降级路径的实测。
         const { zstdDecompressSync: probe } = await import('node:zlib');
         const zstdOk = typeof probe === 'function';
-        const expectBad = zstdOk ? 4 : 1;
+        const expectBad = zstdOk ? 8 : 1;
         const dump = scan.corrupt.map((c) => `${c.path} ← ${c.reason}`).join(' | ');
         ok(scan.ok === false && scan.corruptCount === expectBad, `扫描检出 ${expectBad} 个损坏（实际 ${scan.corruptCount}）`);
         if (zstdOk) {
           ok(scan.corrupt.some((c) => c.path.includes('enc-magic')), `坏魔数检出: ${dump}`);
           ok(scan.corrupt.some((c) => c.path.includes('enc-trunc')), '截断帧检出');
           ok(scan.corrupt.some((c) => c.path.includes('enc-single') && c.reason.includes('容器契约')), `单帧重写违反容器契约检出（#1047 形态）: ${dump}`);
+          ok(scan.corrupt.some((c) => c.path.includes('enc-trail') && c.reason.includes('容器契约')), `首帧尾随空行检出（字节精确契约）: ${dump}`);
+          ok(scan.corrupt.some((c) => c.path.includes('enc-lead') && c.reason.includes('容器契约')), '首帧前导空行检出');
+          ok(scan.corrupt.some((c) => c.path.includes('enc-notail') && c.reason.includes('容器契约')), '首帧缺行尾检出');
+          ok(scan.corrupt.some((c) => c.path.includes('enc-skip') && c.reason.includes('skippable')), `skippable 前导帧检出（宿主拒非数据帧）: ${dump}`);
         } else {
-          ok(scan.skippedCount === 4, `无 zstd 运行时：4 个 .zstd 全部标记 skipped 而非损坏（实际 ${scan.skippedCount}）`);
+          ok(scan.skippedCount === 8, `无 zstd 运行时：8 个 .zstd 全部标记 skipped 而非损坏（实际 ${scan.skippedCount}）`);
           ok(scan.corrupt.every((c) => !c.path.endsWith('.zstd')), `损坏清单只含 raw 文件: ${dump}`);
           ok(scan.summary.includes('未能深度校验'), '扫描汇总提示 skipped');
         }
@@ -865,12 +889,15 @@ async function main() {
         const cmdScan = await mock20.handler('doctor');
         ok(cmdScan.kind === 'error' && cmdScan.text.includes('/backup doctor --repair'), '命令面 doctor 报告损坏并提示修复用法');
 
-        const repairTargets = zstdOk ? ['enc-magic', 'enc-trunc', 'enc-single', 'raw-gap'] : ['raw-gap'];
+        const repairTargets = zstdOk
+          ? ['enc-magic', 'enc-trunc', 'enc-single', 'enc-trail', 'enc-lead', 'enc-notail', 'enc-skip', 'raw-gap']
+          : ['raw-gap'];
         const repair = await mock20.tool().execute({ mode: 'doctor', selector: 'latest', repair: true }, {});
         ok(repair.ok === true && repair.repaired.length === expectBad, `定点修复 ${expectBad} 个（实际 ${repair.repaired.length}）`);
         if (zstdOk) {
           ok(await fs.readFile(path.join(sessDir, 'enc-magic', 'session.jsonl.zstd')).then((b) => b.equals(good)), '坏魔数文件已还原为健康字节');
           ok(await fs.readFile(path.join(sessDir, 'enc-single', 'session.jsonl.zstd')).then((b) => b.equals(good)), '单帧重写文件已还原为多帧健康字节');
+          ok(await fs.readFile(path.join(sessDir, 'enc-skip', 'session.jsonl.zstd')).then((b) => b.equals(good)), 'skippable 前导文件已还原为健康字节');
         }
         ok(await fs.readFile(path.join(sessDir, 'raw-gap', 'session.jsonl'), 'utf8').then((t) => t === rawGood.toString('utf8')), 'seq 跳号文件已还原');
         let keptCount = 0;
@@ -943,12 +970,14 @@ async function main() {
         const rawGood = Buffer.from(rawLines.slice(0, 3).join('\n'), 'utf8');
         await fs.mkdir(path.join(sessDir, 'enc-a'), { recursive: true });
         await fs.writeFile(path.join(sessDir, 'enc-a', 'session.jsonl.zstd'), good);
-        // enc-single：先写健康多帧（进归档，供 doctor --repair 定点还原），弄坏动作在 doctor 段
+        // enc-single/enc-trail/enc-skip：先写健康多帧（进归档，供 doctor --repair 定点还原），弄坏动作在 doctor 段
         const { zstdDecompressSync: probe23 } = await import('node:zlib');
         const zstd23 = typeof probe23 === 'function';
         if (zstd23) {
-          await fs.mkdir(path.join(sessDir, 'enc-single'), { recursive: true });
-          await fs.writeFile(path.join(sessDir, 'enc-single', 'session.jsonl.zstd'), good);
+          for (const d of ['enc-single', 'enc-trail', 'enc-skip']) {
+            await fs.mkdir(path.join(sessDir, d), { recursive: true });
+            await fs.writeFile(path.join(sessDir, d, 'session.jsonl.zstd'), good);
+          }
         }
         await fs.mkdir(path.join(sessDir, 'raw-b'), { recursive: true });
         await fs.writeFile(path.join(sessDir, 'raw-b', 'session.jsonl'), rawGood);
@@ -987,21 +1016,30 @@ async function main() {
           srv.kill();
         }
 
-        // doctor：弄坏 raw 文件 + 单帧重写（#1047 形态，rescue.mjs 的容器契约校验）→ rescue 检出并定点修复
+        // doctor：弄坏 raw 文件 + 单帧重写/首帧尾随空行/skippable 前导（#1047/#66 形态，
+        // rescue.mjs 的容器契约校验）→ rescue 检出并定点修复
         await fs.writeFile(path.join(sessDir, 'raw-b', 'session.jsonl'), [rawLines[0], JSON.stringify({ type: 'user/message', seq: 0 }), JSON.stringify({ type: 'user/message', seq: 5 })].join('\n'));
         if (zstd23) {
           await fs.writeFile(path.join(sessDir, 'enc-single', 'session.jsonl.zstd'), zlib.zstdCompressSync(`${makeSessionLogLines('sess-r2').join('\n')}\n`));
+          await fs.writeFile(path.join(sessDir, 'enc-trail', 'session.jsonl.zstd'), Buffer.concat([zlib.zstdCompressSync(`${makeSessionLogLines('sess-r3')[0]}\n\n`), zlib.zstdCompressSync(`${makeSessionLogLines('sess-r3')[1]}\n`)]));
+          const skipHead = Buffer.alloc(16);
+          skipHead.writeUInt32LE(0x184d2a50, 0);
+          skipHead.writeUInt32LE(8, 4);
+          await fs.writeFile(path.join(sessDir, 'enc-skip', 'session.jsonl.zstd'), Buffer.concat([skipHead, zlib.zstdCompressSync(`${makeSessionLogLines('sess-r4')[0]}\n`), zlib.zstdCompressSync(`${makeSessionLogLines('sess-r4')[1]}\n`)]));
         }
         const doc = r(['doctor']);
         ok(doc.status === 1 && doc.stdout.includes('raw-b'), `rescue doctor 检出损坏: ${(doc.stdout.match(/❌[^\n]*/) || ['(无)']).join(' ')}`);
         if (zstd23) {
           ok(doc.stdout.includes('enc-single') && doc.stdout.includes('容器契约'), `rescue doctor 检出单帧重写（#66）: ${(doc.stdout.match(/❌[^\n]*/) || ['(无)']).join(' ')}`);
+          ok(doc.stdout.includes('enc-trail') && doc.stdout.includes('容器契约'), 'rescue doctor 检出首帧尾随空行');
+          ok(doc.stdout.includes('enc-skip') && doc.stdout.includes('skippable'), 'rescue doctor 检出 skippable 前导帧');
         }
         const rep = r(['doctor', '--repair']);
         ok(rep.status === 0 && rep.stdout.includes('复检全部健康'), `rescue doctor --repair: ${(rep.stdout || rep.stderr).split('\n')[0]}`);
         ok(await fs.readFile(path.join(sessDir, 'raw-b', 'session.jsonl'), 'utf8').then((t) => t === rawGood.toString('utf8')), 'rescue 修复后字节一致');
         if (zstd23) {
           ok(await fs.readFile(path.join(sessDir, 'enc-single', 'session.jsonl.zstd')).then((b) => b.equals(good)), 'rescue 单帧重写已还原为多帧健康字节');
+          ok(await fs.readFile(path.join(sessDir, 'enc-skip', 'session.jsonl.zstd')).then((b) => b.equals(good)), 'rescue skippable 前导已还原为健康字节');
         }
 
         // 空目标机恢复：整个 .dsh 删掉，rescue 独立拉回（vault 凭据还原）


### PR DESCRIPTION
## 问题（#66）

官方讨论区 [deepseek-ai/deepseek-harness#1047](https://github.com/deepseek-ai/deepseek-harness/discussions/1047) 由 ConradLu2740 审计指出（已对照源码核实属实并在原帖回复）：doctor 的 `decodeZstdLog` 把全部帧解压后拼接成逻辑行流，`validateSessionLines` 只校验「首行 SessionHeader + seq 连续」，**不校验宿主 `assertZstdHeaderFrame` 的「首帧解出恰好一行 header」容器契约**。

后果：外部工具把整份日志重写为单个 zstd 帧（`zstd.compress(whole_plaintext)`，#1047 复现方式）的文件——内容完整可解、行级校验全过——doctor 判 OK、永不进 `--repair`，而宿主读端整体拒载（session.list 500）。用户误以为有健康备份兜底。

## 修复

- `lib/index.js` 与 `rescue/rescue.mjs` **同步**修改（两份独立实现）：
  - `decodeZstdLog` 返回 `{ lines, headerFrameLines }`——首个**数据帧**（zstd 魔数，非 skippable）解出的行数；
  - `validateSessionFile` 的 `.zstd` 分支增判：`headerFrameLines !== 1` 即 bad，reason 点明容器契约与单帧重写形态。
- raw `.jsonl` 文件无帧概念，不受影响；skippable 前导帧被正确跳过（只认数据帧）。

## 验收（对照 #66 的三条标准）

1. ✅ smoke 场景 20 加 `enc-single` 单帧重写样本（`zstdCompressSync(全部行)`，即 #1047 复现方式）→ 检出 bad（reason 含「容器契约」）+ `--repair` 从归档还原为多帧健康字节；
2. ✅ 正常多帧文件零误报（`enc-good` 断言保持）；smoke **208/208**、settings 45/45、client 20/20、e2e-host 32/32 全绿（Node 22 本机；CI 矩阵含 Node 20 降级路径——skipped 计数断言同步更新为 4）；
3. ✅ doctor bad 集合 ⊇ 宿主拒读集合：单帧重写是宿主拒读而原 doctor 漏检的唯一形态，本 PR 补齐。
4. ✅ rescue 通道（进程外 `rescue.mjs` CLI 实弹，场景 23）同步检出并修复单帧重写。

Closes #66