### PR TITLE
fix(doctor): 行级 SessionHeader 校验对齐宿主 isHeaderLine

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1944,9 +1944,20 @@ export function apply(ctx, pluginConfig) {
     } catch {
       return `首行不是 JSON（${snippet(String(lines[0]))}）`;
     }
-    if (!header || typeof header !== 'object' || header.type !== 'session' || typeof header.id !== 'string') {
-      return '首行不是有效的 SessionHeader（缺 type:"session" 或 id）';
-    }
+  if (!header || typeof header !== 'object') return '首行不是对象';
+  // 行级 SessionHeader 校验对齐宿主 isHeaderLine（0.1.2-rc.1 是 0.1.1-rc.2 的严格
+  // 超集——多查 seedLength；以严格者为准覆盖双列车）。宿主读端 isHeaderLine 通过后，
+  // fromHeaderLine 还会拒绝退役字段 sandboxMode/approvalPolicy——两者合并即"能否加载"，
+  // 故 doctor 全检。字段语义取自 @deepseek-ai/dsh-session-persistence-jsonl format.ts。
+  if (header.type !== 'session') return `首行 type 不是 "session"（${snippet(JSON.stringify(header.type) ?? String(header.type))}）`;
+  if (typeof header.version !== 'number') return `首行 version 不是 number（${snippet(typeof header.version)}）`;
+  if (typeof header.id !== 'string') return '首行 id 不是 string';
+  if (typeof header.createdAt !== 'number' || !Number.isSafeInteger(header.createdAt) || header.createdAt < 0 || Object.is(header.createdAt, -0)) return `首行 createdAt 非法（须非负安全整数，实际 ${snippet(String(header.createdAt))}）`;
+  if (typeof header.delegationDepth !== 'number' || !Number.isSafeInteger(header.delegationDepth) || header.delegationDepth < 0 || Object.is(header.delegationDepth, -0)) return `首行 delegationDepth 非法（须非负安全整数，实际 ${snippet(String(header.delegationDepth))}）`;
+  if (header.seedLength !== undefined && (typeof header.seedLength !== 'number' || !Number.isSafeInteger(header.seedLength) || header.seedLength < 0 || Object.is(header.seedLength, -0))) return '首行 seedLength 非法（须 undefined 或非负安全整数）';
+  if (header.origin !== undefined && header.origin !== 'subagent') return '首行 origin 非法（须 undefined 或 "subagent"）';
+  if (header.agentPreset !== undefined && typeof header.agentPreset !== 'string') return '首行 agentPreset 非法（须 undefined 或 string）';
+  if (Object.hasOwn(header, 'sandboxMode') || Object.hasOwn(header, 'approvalPolicy')) return '首行含退役字段 sandboxMode/approvalPolicy——宿主读端拒绝';
     let nextSeq = 0;
     for (let i = 1; i < lines.length; i++) {
       let rec;

--- a/rescue/rescue.mjs
+++ b/rescue/rescue.mjs
@@ -283,9 +283,20 @@ function validateSessionLines(lines) {
   } catch {
     return `首行不是 JSON（${snippet(String(lines[0]))}）`;
   }
-  if (!header || typeof header !== 'object' || header.type !== 'session' || typeof header.id !== 'string') {
-    return '首行不是有效的 SessionHeader（缺 type:"session" 或 id）';
-  }
+  if (!header || typeof header !== 'object') return '首行不是对象';
+  // 行级 SessionHeader 校验对齐宿主 isHeaderLine（0.1.2-rc.1 是 0.1.1-rc.2 的严格
+  // 超集——多查 seedLength；以严格者为准覆盖双列车）。宿主读端 isHeaderLine 通过后，
+  // fromHeaderLine 还会拒绝退役字段 sandboxMode/approvalPolicy——两者合并即"能否加载"，
+  // 故 doctor 全检。字段语义取自 @deepseek-ai/dsh-session-persistence-jsonl format.ts。
+  if (header.type !== 'session') return `首行 type 不是 "session"（${snippet(JSON.stringify(header.type) ?? String(header.type))}）`;
+  if (typeof header.version !== 'number') return `首行 version 不是 number（${snippet(typeof header.version)}）`;
+  if (typeof header.id !== 'string') return '首行 id 不是 string';
+  if (typeof header.createdAt !== 'number' || !Number.isSafeInteger(header.createdAt) || header.createdAt < 0 || Object.is(header.createdAt, -0)) return `首行 createdAt 非法（须非负安全整数，实际 ${snippet(String(header.createdAt))}）`;
+  if (typeof header.delegationDepth !== 'number' || !Number.isSafeInteger(header.delegationDepth) || header.delegationDepth < 0 || Object.is(header.delegationDepth, -0)) return `首行 delegationDepth 非法（须非负安全整数，实际 ${snippet(String(header.delegationDepth))}）`;
+  if (header.seedLength !== undefined && (typeof header.seedLength !== 'number' || !Number.isSafeInteger(header.seedLength) || header.seedLength < 0 || Object.is(header.seedLength, -0))) return '首行 seedLength 非法（须 undefined 或非负安全整数）';
+  if (header.origin !== undefined && header.origin !== 'subagent') return '首行 origin 非法（须 undefined 或 "subagent"）';
+  if (header.agentPreset !== undefined && typeof header.agentPreset !== 'string') return '首行 agentPreset 非法（须 undefined 或 string）';
+  if (Object.hasOwn(header, 'sandboxMode') || Object.hasOwn(header, 'approvalPolicy')) return '首行含退役字段 sandboxMode/approvalPolicy——宿主读端拒绝';
   let nextSeq = 0;
   for (let i = 1; i < lines.length; i++) {
     let rec;

--- a/scripts/e2e-host.mjs
+++ b/scripts/e2e-host.mjs
@@ -287,7 +287,7 @@ async function main() {
     // 会话日志布局对齐 @deepseek-ai/dsh-session-persistence-jsonl：
     // 两份都先写健康内容 → 备份（归档持健康副本）→ 再弄坏一份现场
     const sessRoot = path.join(home, 'sessions', '--e2e--');
-    const headerLine = JSON.stringify({ type: 'session', version: 0, id: 'sess-e2e', createdAt: '2026-08-25T00:00:00.000Z', delegationDepth: 0 });
+    const headerLine = JSON.stringify({ type: 'session', version: 0, id: 'sess-e2e', createdAt: 1724544000000, delegationDepth: 0 });
     const healthy = Buffer.concat([
       zstdCompressSync(`${headerLine}\n`),
       zstdCompressSync(`${JSON.stringify({ type: 'user/message', seq: 0 })}\n${JSON.stringify({ type: 'user/message', seq: 1 })}\n`),
@@ -452,7 +452,7 @@ async function main() {
     const qDir = path.join(home, 'sessions', '--e2e-q--', 'raw-x');
     fs.mkdirSync(qDir, { recursive: true });
     const healthyText = [
-      JSON.stringify({ type: 'session', version: 0, id: 'sess-q', createdAt: '2026-08-26T00:00:00.000Z', delegationDepth: 0 }),
+      JSON.stringify({ type: 'session', version: 0, id: 'sess-q', createdAt: 1724630400000, delegationDepth: 0 }),
       JSON.stringify({ type: 'user/message', seq: 0 }),
       JSON.stringify({ type: 'user/message', seq: 1 }),
     ].join('\n');

--- a/scripts/e2e-upgrade.mjs
+++ b/scripts/e2e-upgrade.mjs
@@ -212,7 +212,7 @@ async function main() {
 
   // 老用户的健康会话日志（升级后归档 A 必须还能恢复它）
   const sessRoot = path.join(home, 'sessions', '--upgrade--');
-  const headerLine = JSON.stringify({ type: 'session', version: 0, id: 'sess-upgrade', createdAt: '2026-09-07T00:00:00.000Z', delegationDepth: 0 });
+  const headerLine = JSON.stringify({ type: 'session', version: 0, id: 'sess-upgrade', createdAt: 1757116800000, delegationDepth: 0 });
   const healthy = Buffer.concat([
     zstdCompressSync(`${headerLine}\n`),
     zstdCompressSync(`${JSON.stringify({ type: 'user/message', seq: 0 })}\n${JSON.stringify({ type: 'user/message', seq: 1 })}\n`),

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -257,7 +257,7 @@ function makeTarGz(entries) {
  * 其后每批一帧；packed 行（text-chunks）横跨 seq2..4，随后裸事件接续。
  */
 function makeSessionLogLines(id) {
-  const header = JSON.stringify({ type: 'session', version: 0, id, createdAt: '2026-08-25T00:00:00.000Z', delegationDepth: 0 });
+  const header = JSON.stringify({ type: 'session', version: 0, id, createdAt: 1724544000000, delegationDepth: 0 });
   const ev = (seq) => JSON.stringify({ type: 'user/message', seq });
   const packedRow = JSON.stringify({ type: 'text-chunks', seq0: 2, time0: 1000, data: { turn: 0, step: 0, index: 0, dt: [5, 7], texts: ['a', 'b', 'c'] } });
   return [header, ev(0), ev(1), packedRow, ev(5), ev(6)];
@@ -1279,6 +1279,81 @@ async function main() {
         if (keep) ok(await fs.readFile(path.join(mdsh, 'skills', keep), 'utf8') === 'TAMPERED', '留档内容是覆盖前的篡改值');
       } finally {
         await fs.rm(mdir, { recursive: true, force: true });
+      }
+    }
+
+    // doctor 行级 SessionHeader 校验对齐宿主 isHeaderLine（0.1.2-rc.1 严格超集）：
+    // 八种坏 header 形态各一例 + 一例健康对照，全走多帧 zstd 容器。
+    console.log('21) doctor：SessionHeader 形态负样本（对齐宿主 isHeaderLine）');
+    {
+      const envH = await mkTmpHome();
+      try {
+        const mockH = makeCtx({ home: envH.home, dsh: envH.dsh });
+        plugin(mockH.ctx, {});
+        const sessDir = path.join(envH.dsh, 'sessions', '--hdr--');
+        const { zstdCompressSync: zC } = await import('node:zlib');
+        const zstdOk = typeof zC === 'function';
+        const goodHeader = JSON.stringify({ type: 'session', version: 0, id: 'hdr-good', createdAt: 1724544000000, delegationDepth: 0 });
+        const badHeaders = [
+          ['hdr-missing-type', JSON.stringify({ version: 0, id: 'x', createdAt: 1724544000000, delegationDepth: 0 })],
+          ['hdr-no-id', JSON.stringify({ type: 'session', version: 0, createdAt: 1724544000000, delegationDepth: 0 })],
+          ['hdr-int-agentPreset', JSON.stringify({ type: 'session', version: 0, id: 'x', createdAt: 1724544000000, delegationDepth: 0, agentPreset: 42 })],
+          ['hdr-wrong-type', JSON.stringify({ type: 'foo', version: 0, id: 'x', createdAt: 1724544000000, delegationDepth: 0 })],
+          ['hdr-no-version', JSON.stringify({ type: 'session', id: 'x', createdAt: 1724544000000, delegationDepth: 0 })],
+          ['hdr-string-createdAt', JSON.stringify({ type: 'session', version: 0, id: 'x', createdAt: '2026-08-25T00:00:00.000Z', delegationDepth: 0 })],
+          ['hdr-neg-depth', JSON.stringify({ type: 'session', version: 0, id: 'x', createdAt: 1724544000000, delegationDepth: -1 })],
+          ['hdr-retired', JSON.stringify({ type: 'session', version: 0, id: 'x', createdAt: 1724544000000, delegationDepth: 0, sandboxMode: true })],
+          ['hdr-bad-origin', JSON.stringify({ type: 'session', version: 0, id: 'x', createdAt: 1724544000000, delegationDepth: 0, origin: 'other' })],
+          ['hdr-float-seedLength', JSON.stringify({ type: 'session', version: 0, id: 'x', createdAt: 1724544000000, delegationDepth: 0, seedLength: 1.5 })],
+          ['hdr-no-createdAt', JSON.stringify({ type: 'session', version: 0, id: 'x', delegationDepth: 0 })],
+        ];
+        const evLine = JSON.stringify({ type: 'user/message', seq: 0 });
+        const build = (hdr) => zstdOk
+          ? Buffer.concat([zC(`${hdr}\n`), zC(`${evLine}\n`)])
+          : Buffer.from(`placeholder-${hdr.slice(0, 8)}`);
+        // 先把所有 9 个目录都写成健康内容并备份——归档持健康副本，供 doctor --repair 还原
+        for (const [dirName] of [['hdr-good', goodHeader], ...badHeaders]) {
+          await fs.mkdir(path.join(sessDir, dirName), { recursive: true });
+          await fs.writeFile(path.join(sessDir, dirName, 'session.jsonl.zstd'), build(goodHeader));
+        }
+        ok((await mockH.tool().execute({ mode: 'backup' }, {})).ok === true, 'header 形态场景备份成功');
+        // 备份后再覆盖 8 个坏 header 现场（健康对照 hdr-good 不动）
+        for (const [dirName, hdr] of badHeaders) {
+          await fs.writeFile(path.join(sessDir, dirName, 'session.jsonl.zstd'), build(hdr));
+        }
+
+        const scan = await mockH.tool().execute({ mode: 'doctor' }, {});
+        const dump = scan.corrupt.map((c) => `${c.path} ← ${c.reason}`).join(' | ');
+        if (zstdOk) {
+          ok(scan.ok === false && scan.corruptCount === 11, `扫描检出 11 个坏 header（实际 ${scan.corruptCount}）: ${dump}`);
+          ok(scan.corrupt.some((c) => c.path.includes('hdr-wrong-type') && c.reason.includes('type')), `wrong-type 检出: ${dump}`)
+          ok(scan.corrupt.some((c) => c.path.includes('hdr-missing-type') && c.reason.includes('type')), `缺 type 字段不崩溃且检出（snippet undefined 回归锁）: ${dump}`)
+          ok(scan.corrupt.some((c) => c.path.includes('hdr-no-id') && c.reason.includes('id')), `缺 id 检出（review P2 补盲）: ${dump}`)
+          ok(scan.corrupt.some((c) => c.path.includes('hdr-int-agentPreset') && c.reason.includes('agentPreset')), `非字符串 agentPreset 检出（review P2 补盲）: ${dump}`);
+          ok(scan.corrupt.some((c) => c.path.includes('hdr-no-version') && c.reason.includes('version')), `缺 version 检出: ${dump}`);
+          ok(scan.corrupt.some((c) => c.path.includes('hdr-string-createdAt') && c.reason.includes('createdAt')), `字符串 createdAt 检出（旧 bug 形态）: ${dump}`);
+          ok(scan.corrupt.some((c) => c.path.includes('hdr-neg-depth') && c.reason.includes('delegationDepth')), `负 delegationDepth 检出: ${dump}`);
+          ok(scan.corrupt.some((c) => c.path.includes('hdr-retired') && c.reason.includes('退役')), `退役字段 sandboxMode 检出: ${dump}`);
+          ok(scan.corrupt.some((c) => c.path.includes('hdr-bad-origin') && c.reason.includes('origin')), `坏 origin 检出: ${dump}`);
+          ok(scan.corrupt.some((c) => c.path.includes('hdr-float-seedLength') && c.reason.includes('seedLength')), `非整数 seedLength 检出: ${dump}`);
+          ok(scan.corrupt.some((c) => c.path.includes('hdr-no-createdAt') && c.reason.includes('createdAt')), `缺 createdAt 检出: ${dump}`);
+          ok(!scan.corrupt.some((c) => c.path.includes('hdr-good')), `健康 header 零误报: ${dump}`);
+        } else {
+          ok(scan.skippedCount === 12, `无 zstd 运行时：12 个 .zstd 全部 skipped（实际 ${scan.skippedCount}）`);
+        }
+
+        const repairTargets = zstdOk ? badHeaders.map(([d]) => d) : [];
+        const repair = await mockH.tool().execute({ mode: 'doctor', selector: 'latest', repair: true }, {});
+        if (zstdOk) {
+          ok(repair.ok === true && repair.repaired.length === 11, `定点修复 11 个坏 header（实际 ${repair.repaired.length}）`);
+          for (const dirName of repairTargets) {
+            ok(await fs.readFile(path.join(sessDir, dirName, 'session.jsonl.zstd')).then((b) => b.equals(build(goodHeader))), `${dirName} 已还原为健康 header`);
+          }
+        }
+        const rescan = await mockH.tool().execute({ mode: 'doctor' }, {});
+        ok(rescan.ok === true, `修复后复扫全绿${rescan.ok === false ? `: ${JSON.stringify(rescan.corrupt).slice(0, 160)}` : ''}`);
+      } finally {
+        await fs.rm(envH.dir, { recursive: true, force: true });
       }
     }
 


### PR DESCRIPTION
## 闭环 0.11.0 已知遗留

> doctor 行级 SessionHeader 校验弱于宿主 `isHeaderLine`（缺 createdAt/version/delegationDepth 字段检查）——0.11.0 Release Notes

## 改动
- 首行校验从「type+id」扩到宿主完整语义（以 0.1.2-rc.1 为准——它是 0.1.1-rc.2 的严格超集）：
  - `version: number`、`createdAt`/`delegationDepth` 非负安全整数三连（含 `-0` 拒绝）
  - `seedLength` 可选分支、`origin` 枚举（`undefined | "subagent"`）、`agentPreset` 类型
  - 退役字段 `sandboxMode`/`approvalPolicy`（`Object.hasOwn`，对齐宿主读端 `fromHeaderLine` 拒绝）
- **静态证明不误判**：宿主写端 `toHeaderLine` 的全部产出形态（有/无 seedLength × origin × agentPreset）均通过新检查
- 修复自查发现的崩溃点：`snippet(JSON.stringify(undefined))` 在缺 `type` 字段时 TypeError（已加回归锁负样本）
- `lib/index.js` 与 `rescue/rescue.mjs`（进程外零依赖副本）逐字同步
- 修正三处 fixture 的 `createdAt`（ISO 字符串 → 数字 epoch——宿主 `isHeaderLine` 要求数字，旧 fixture 其实是宿主拒载形态）
- smoke 新增场景 21：11 种坏 header 负样本 + 健康对照 + 从归档定点修复

## 独立复核
General-agent 对照本机真实宿主编译产物逐字段审计，结论 **ALIGN**（合并语义完全等价、写端产物零误判、两副本一致、无 undefined 崩溃点）；复核抓出的 2 个 P2 测试盲区（`id`/`agentPreset` 分支零覆盖）已补样本。

## 测试
| 套件 | 结果 |
|---|---|
| smoke（新增场景 21：11 坏 header + 健康对照 + 修复） | 243/243 ✅ |
| settings / client | 45/45、20/20 ✅ |
| e2e-host 0.1.1-rc.2 / 0.1.2-rc.1 | 32/32、32/32 ✅ |
| 原地升级 e2e（同列车 + 跨列车救援） | 14/14、14/14 ✅ |